### PR TITLE
Feature/lk/fix spec parsing errors

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,6 +32,8 @@ export class AppComponent {
       setTimeout(() => {
         location.hash = loadingHash;
       });
+    }, (error) => {
+      console.error('There was an error while fetching the swagger spec', error);
     });
   }
 }

--- a/src/app/operations/operation-body-parameter.component.ts
+++ b/src/app/operations/operation-body-parameter.component.ts
@@ -60,22 +60,21 @@ export class OperationBodyParameterComponent implements OnInit {
     let schema = parameter.schema
     let properties: any[] = [];
 
-    if (schema && schema.allOf ) {
-      schema.allOf.forEach((schemaItem) => {
+    function concatPropsForItem(schemaItem) {
+      if (schemaItem && schemaItem.allOf) {
+        schemaItem.allOf.forEach(concatPropsForItem);
+      } else if (schemaItem && schemaItem.properties){
         properties = properties.concat(
           Object.keys(schemaItem.properties)
             .map((key)=> {
               return Object.assign(schemaItem.properties[key], {name: key});
             }).filter((item) => !item.readOnly)
         );
-      });
-    } else if (schema.properties){
-        properties = properties.concat(
-          Object.keys(schema.properties)
-            .map((key)=> {
-              return Object.assign(schema.properties[key], {name: key});
-            }).filter((item) => !item.readOnly)
-        );
+      }
+    }
+
+    if (schema && schema.allOf || schema.properties) {
+      concatPropsForItem(schema)
     } else if (schema.type === 'array') {
       properties = [parameter]
     }

--- a/src/app/services/swagger.service.ts
+++ b/src/app/services/swagger.service.ts
@@ -17,7 +17,8 @@ export class SwaggerService {
       let isLocalhost = hostname.includes('localhost');
       let specUrl: string;
       if (isLocalhost) {
-        specUrl = 'https://spec.staging.rasterfoundry.com';
+        specUrl = 'https://spec.rasterfoundry.com';
+        // specUrl = '/assets/spec.yml'; // uncomment to use assets/spec.yml as the spec instead
       } else {
         let parts = hostname.split('.');
         parts[0] = 'spec';


### PR DESCRIPTION
## Overview
Fix parsing of nested allOf in spec

Fix fetching staging spec in dev

## Notes
I used a recursive method, since I figure a spec can really only have so much nesting, and it's probably less than the browser's max stack size.

## Testing

- Verify that fetching the spec no longer results in a CORS error (caused by a 301 from s3)
- Verify that the export endpoints now render correctly

Closes #21 