### PR TITLE
Fix wrong curl urls on production

### DIFF
--- a/src/app/operations/operation-sample-request.component.ts
+++ b/src/app/operations/operation-sample-request.component.ts
@@ -39,7 +39,7 @@ export class OperationSampleRequestComponent implements OnInit, OnChanges {
 
 
   ngOnInit() {
-    this.domain = this.settingsService.domain;
+    this.domain = this.settingsService.apiUrl;
   }
 
   ngOnChanges(changes) {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -89,7 +89,7 @@ export class AuthService {
   }
 
   public getSessionToken(refreshToken: string): Observable<any> {
-    let requestUrl = `${this.settingsService.domain}/tokens`
+    let requestUrl = `${this.settingsService.apiUrl}/tokens`
     return this.http.post(requestUrl, {refresh_token: refreshToken});
   }
 }

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -2,9 +2,26 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class SettingsService {
+  private hostname : string;
 
-  constructor() { }
+  constructor() {
+    let isLocalhost = location.host.includes('localhost');
+    this.hostname = isLocalhost ? 'app.rasterfoundry.com' : location.host;
+  }
 
-  public domain: string = 'https://app.staging.rasterfoundry.com/api';
+  get specUrl() {
+    let parts = this.hostname.split('.');
 
+    parts[0] = 'spec';
+    let specUrl = 'https://' + parts.join('.');
+    // let specUrl = '/assets/spec.yml'; // uncomment to use assets/spec.yml as the spec instead
+
+    return specUrl;
+  }
+
+  get apiUrl() {
+    let parts = this.hostname.split('.');
+    parts[0] = 'app';
+    return `https://${parts.join('.')}/api`;
+  }
 }

--- a/src/app/services/swagger.service.ts
+++ b/src/app/services/swagger.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
+import { SettingsService } from '../services/settings.service';
 
 declare var SwaggerParser:any;
 
@@ -9,23 +10,11 @@ export class SwaggerService {
   spec: any;
   error: any;
 
-  constructor(private http: Http) { }
+  constructor(private http: Http, private settingsService: SettingsService) { }
 
   public fetchSpec(): Promise<any> {
     return new Promise((resolve, reject) => {
-      let hostname = location.host;
-      let isLocalhost = hostname.includes('localhost');
-      let specUrl: string;
-      if (isLocalhost) {
-        specUrl = 'https://spec.rasterfoundry.com';
-        // specUrl = '/assets/spec.yml'; // uncomment to use assets/spec.yml as the spec instead
-      } else {
-        let parts = hostname.split('.');
-        parts[0] = 'spec';
-        specUrl = 'https://' + parts.join('.');
-      }
-
-      this.http.get(specUrl).subscribe(response => {
+      this.http.get(this.settingsService.specUrl).subscribe(response => {
         try {
           let parsed = SwaggerParser.YAML.parse(response.text());
           SwaggerParser.dereference(parsed).then((file: Object) => {


### PR DESCRIPTION
## Overview

Dynamically calculate curl and spec urls in settingsService instead of controllers

## Demo

![image](https://cloud.githubusercontent.com/assets/4392704/26326433/28297bac-3f09-11e7-8553-e7047c48fa03.png)

## Testing

- Verify that changing the overwritten hostname in `settings.service.ts ` is reflected in the curl urls
